### PR TITLE
feat: remove empty fields

### DIFF
--- a/src/components/ComponentEditor/index.tsx
+++ b/src/components/ComponentEditor/index.tsx
@@ -1,5 +1,5 @@
 import { Form, Field, Input, Button, FormAPI } from "@grafana/ui";
-import { Block, toArgument } from "../../lib/river";
+import { Block, toBlock } from "../../lib/river";
 import PrometheusRemoteWrite from "./components/PrometheusRemoteWrite";
 import PrometheusExporterRedis from "./components/PrometheusExporterRedis";
 import PrometheusScrape from "./components/PrometheusScrape";
@@ -31,16 +31,8 @@ const ComponentEditor = ({
 
   return (
     <Form
-      onSubmit={async (values) => {
-        updateComponent(
-          new Block(
-            component.name,
-            values.label,
-            Object.keys(values)
-              .filter((x) => x !== "label")
-              .map((x) => toArgument(x, values[x]))
-          )
-        );
+      onSubmit={async ({ label, ...args }) => {
+        updateComponent(toBlock(component.name, args, label)!);
       }}
       defaultValues={formValues}
     >

--- a/src/components/ConfigEditor/index.tsx
+++ b/src/components/ConfigEditor/index.tsx
@@ -192,7 +192,6 @@ const ConfigEditor = () => {
         null, // wordSeparators
         false // captureMatches
       );
-      console.log(existingRefs);
       for (const ref of existingRefs) {
         edits.push({
           range: ref.range,

--- a/src/lib/river.ts
+++ b/src/lib/river.ts
@@ -139,19 +139,30 @@ export function UnmarshalBlock(n: Parser.SyntaxNode): Block {
   return new Block(name, label, args);
 }
 
-export function toArgument(k: string, v: any): Argument {
+export function toArgument(k: string, v: any): Argument | null {
   switch (typeof v) {
     case "string":
     case "number":
+      if (v === "" || v === null) return null;
       return new Attribute(k, v);
     default:
       if (Array.isArray(v)) {
         return new Attribute(k, v);
       }
-      return new Block(
-        k,
-        null,
-        Object.keys(v).map((x) => toArgument(x, v[x]))
-      );
+      return toBlock(k, v);
   }
+}
+
+export function toBlock(k: string, v: any, label?: string): Block | null {
+  // flatmap instead of filter to avoid introducing the null type
+  const args = Object.keys(v).flatMap((x) => {
+    const arg = toArgument(x, v[x]);
+    if (arg == null) {
+      return [];
+    }
+    return [arg];
+  });
+  if (label) return new Block(k, label, args);
+  if (args.length === 0) return null;
+  return new Block(k, label, args);
 }


### PR DESCRIPTION
This prevents the config file from filling up with empty string values by stripping them when converting between the form and component.

In the future, we might need to cross-check this with the default values of the component as an empty string could be the desired value.