### PR TITLE
refactor: split parsing from the codelens provider

### DIFF
--- a/src/components/ComponentEditor/inputs/ReferenceSelect.tsx
+++ b/src/components/ComponentEditor/inputs/ReferenceSelect.tsx
@@ -37,14 +37,14 @@ const ReferenceSelect = ({
           {...field}
           options={[
             ...components
-              .filter((component) =>
-                ComponentLookup[exportName].includes(component.name)
+              .filter(({ block }) =>
+                ComponentLookup[exportName].includes(block.name)
               )
-              .map((component) => {
+              .map(({ block }) => {
                 return {
-                  label: `${component.label} [${component.name}]`,
+                  label: `${block.label} [${block.name}]`,
                   value: {
-                    "-reference": `${component.name}.${component.label}.${exportName}`,
+                    "-reference": `${block.name}.${block.label}.${exportName}`,
                   },
                 };
               }),

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -1,15 +1,17 @@
 import React, { useContext, useState } from "react";
-
+import Parser from "web-tree-sitter";
 import { Block } from "./lib/river";
 
+export type Component = { block: Block; node: Parser.SyntaxNode };
+
 const ComponentContext = React.createContext<{
-  components: Block[];
-  setComponents: (b: Block[]) => void;
-}>({ components: [], setComponents: (_: Block[]) => { } });
+  components: Component[];
+  setComponents: (b: Component[]) => void;
+}>({ components: [], setComponents: (_: Component[]) => { } });
 
 // Component provider
 export const ComponentProvider = ({ children }: React.PropsWithChildren) => {
-  const [components, setComponents] = useState<Block[]>([]);
+  const [components, setComponents] = useState<Component[]>([]);
   // Remember to pass the state and the updater function to the provider
   return (
     <ComponentContext.Provider value={{ components, setComponents }}>


### PR DESCRIPTION
This decouples parsing from the codelens provider and creates the groundwork for more efficient parsing.