### PR TITLE
fix: add trailing slash to docs link

### DIFF
--- a/src/components/ConfigEditor/index.tsx
+++ b/src/components/ConfigEditor/index.tsx
@@ -288,7 +288,7 @@ const ConfigEditor = () => {
                   />
                 )}
                 <LinkButton
-                  href={`https://grafana.com/docs/agent/latest/flow/reference/components/${currentComponent.component.name}`}
+                  href={`https://grafana.com/docs/agent/latest/flow/reference/components/${currentComponent.component.name}/`}
                   icon="external-link-alt"
                   variant="secondary"
                   target="_blank"


### PR DESCRIPTION
this avoids one redirect and fixed the link for some components