### PR TITLE
fix: prevent access of faro api if it has not been initialized

### DIFF
--- a/src/components/ComponentEditor/index.tsx
+++ b/src/components/ComponentEditor/index.tsx
@@ -124,7 +124,7 @@ const ComponentEditor = ({
         }
       //@ts-ignore if no module matches, we fall through to the unsupported component path
       default:
-        faro.api.pushEvent("edit_unsupported", { component: component.name });
+        faro.api?.pushEvent("edit_unsupported", { component: component.name });
         return {
           Component: UnsupportedComponent,
           postTransform: id,

--- a/src/components/ComponentList/index.tsx
+++ b/src/components/ComponentList/index.tsx
@@ -172,7 +172,7 @@ const ComponentList = ({ addComponent }: ComponentListProps) => {
                 <Button
                   onClick={() => {
                     addComponent(c.component);
-                    faro.api.pushEvent("added_component", {
+                    faro.api?.pushEvent("added_component", {
                       component: c.name,
                     });
                   }}

--- a/src/components/ExamplesCatalog/index.tsx
+++ b/src/components/ExamplesCatalog/index.tsx
@@ -17,7 +17,7 @@ const ExamplesCatalog = ({ dismiss }: { dismiss: () => void }) => {
           key={item.name}
           onClick={() => {
             setModel(item.source);
-            faro.api.pushEvent("applied_example", { example: item.name });
+            faro.api?.pushEvent("applied_example", { example: item.name });
             dismiss();
           }}
         >


### PR DESCRIPTION
otherwise the application will encounter exceptions when developing locally