### PR TITLE
chore: rename file discovery due to renaming in agent release 0.35

### DIFF
--- a/src/components/ComponentEditor/components/LocalFileMatch.tsx
+++ b/src/components/ComponentEditor/components/LocalFileMatch.tsx
@@ -74,7 +74,7 @@ const Component = ({ methods }: { methods: FormAPI<Record<string, any>> }) => {
   );
 };
 
-const DiscoveryFile = {
+const LocalFileMatch = {
   preTransform(data: Record<string, any>): Record<string, any> {
     return data;
   },
@@ -92,4 +92,4 @@ const DiscoveryFile = {
   Component,
 };
 
-export default DiscoveryFile;
+export default LocalFileMatch;

--- a/src/components/ComponentEditor/index.tsx
+++ b/src/components/ComponentEditor/index.tsx
@@ -25,11 +25,11 @@ import OTelColExporterPrometheus from "./components/OTelColExporterPrometheus";
 import GrafanaCloudAutoconfigure from "./components/modules/GrafanaCloudAutoConfigure";
 import OTelColExporterLoki from "./components/OTelColExporterLoki";
 import PrometheusExporterUnix from "./components/PrometheusExporterUnix";
-import DiscoveryFile from "./components/DiscoveryFile";
 import LokiSourceFile from "./components/LokiSourceFile";
 import LokiRelabel from "./components/LokiRelabel";
 import LokiSourceJournal from "./components/LokiSourceJournal";
 import PrometheusRelabel from "./components/PrometheusRelabel";
+import LocalFileMatch from "./components/LocalFileMatch";
 
 interface ComponentEditorProps {
   updateComponent: (component: Block) => void;
@@ -100,8 +100,8 @@ const ComponentEditor = ({
         return OTelColExporterLoki;
       case "prometheus.exporter.unix":
         return PrometheusExporterUnix;
-      case "discovery.file":
-        return DiscoveryFile;
+      case "local.file_match":
+        return LocalFileMatch;
       case "loki.source.file":
         return LokiSourceFile;
       case "loki.source.journal":

--- a/src/components/ComponentList/index.tsx
+++ b/src/components/ComponentList/index.tsx
@@ -115,11 +115,11 @@ const components: ListEntry[] = [
     component: new Block("loki.relabel", "default", []),
   },
   {
-    name: "discovery.file",
+    name: "local.file_match",
     title: "File discovery",
     meta: ["Discovery", "Logs"],
     icon: "file-alt",
-    component: new Block("discovery.file", "log_files", [
+    component: new Block("local.file_match", "log_files", [
       new Attribute("path_targets", [{ __path__: "/var/log/**/*.log" }]),
     ]),
   },

--- a/src/lib/components.ts
+++ b/src/lib/components.ts
@@ -184,7 +184,7 @@ export const KnownComponents: Record<string, BlockType> = {
       rootfs_path: new LiteralArgument("string", "/"),
     },
   }),
-  "discovery.file": new BlockType({
+  "local.file_match": new BlockType({
     multi: true,
     exports: {
       targets: "list(FileTarget)",


### PR DESCRIPTION
Needs to be merged after the corresponding release has been published in the upstream agent repo