### PR TITLE
refactor: simplify reference select code and disable option creation

### DIFF
--- a/src/components/ComponentEditor/inputs/ReferenceMultiSelect.tsx
+++ b/src/components/ComponentEditor/inputs/ReferenceMultiSelect.tsx
@@ -1,11 +1,10 @@
 import { SelectableValue } from "@grafana/data";
-import { MultiSelect, InputControl } from "@grafana/ui";
-import { Control, get } from "react-hook-form";
+import { InputControl, MultiSelect } from "@grafana/ui";
+import { get } from "react-hook-form";
 import { useState } from "react";
-import { toOptions } from "./ReferenceSelect";
 
 import { useComponentContext } from "../../../state";
-import { ExportType } from "../../../lib/components";
+import { ReferenceSelectProps, toOptions } from "./ReferenceSelectBase";
 
 const ReferenceMultiSelect = ({
   control,
@@ -13,29 +12,17 @@ const ReferenceMultiSelect = ({
   exportName,
   rules,
   width,
-}: {
-  control: Control<Record<string, any>>;
-  name: string;
-  exportName: ExportType;
-  rules?: Object;
-  width?: number;
-}) => {
+  defaultValue,
+}: ReferenceSelectProps<{ "-reference": string }[]>) => {
   const { components } = useComponentContext();
-  const defaultValue = get(control.defaultValuesRef.current, name);
-  const [value, setValue] = useState<Array<SelectableValue<object>>>(() => {
+  defaultValue = defaultValue ?? get(control.defaultValuesRef.current, name);
+  const [value, setValue] = useState<SelectableValue<object>[]>(() => {
     if (!defaultValue) return [];
-    return defaultValue.map((x: SelectableValue<object>) => {
-      if ("-reference" in x)
-        return { label: x["-reference"], value: x, key: x["-reference"] };
-      else return { label: JSON.stringify(x), value: x };
-    });
+    return defaultValue.map((v) => ({ label: v["-reference"], value: v }));
   });
-  const [customOptions, setCustomOptions] = useState<
-    Array<SelectableValue<any>>
-  >([]);
   const targetComponents = toOptions(
     components.map((x) => x.block),
-    exportName
+    exportName,
   );
   return (
     <InputControl
@@ -43,21 +30,13 @@ const ReferenceMultiSelect = ({
       render={({ field: { onChange, ref, ...field } }) => (
         <MultiSelect
           {...field}
-          options={[...targetComponents, ...customOptions]}
+          options={targetComponents}
           allowCustomValue={true}
           onChange={(v) => {
-            onChange(v.map((x) => x.value));
+            onChange(v.map((e: SelectableValue) => e.value));
             setValue(v);
           }}
           value={value}
-          onCreateOption={(newOption) => {
-            const customValue: SelectableValue<object> = {
-              value: JSON.parse(newOption),
-              label: newOption,
-            };
-            setCustomOptions([...customOptions, customValue]);
-            setValue([...value, customValue]);
-          }}
           width={width}
         />
       )}

--- a/src/components/ComponentEditor/inputs/ReferenceSelect.tsx
+++ b/src/components/ComponentEditor/inputs/ReferenceSelect.tsx
@@ -1,112 +1,46 @@
 import { SelectableValue } from "@grafana/data";
 import { Select, InputControl } from "@grafana/ui";
-import { Control } from "react-hook-form";
+import { get } from "react-hook-form";
 import { useState } from "react";
-import { Attribute, Block } from "../../../lib/river";
 
 import { useComponentContext } from "../../../state";
-import {
-  BlockType,
-  ExportType,
-  KnownComponents,
-  KnownModules,
-} from "../../../lib/components";
-
-export function toOptions(
-  components: Block[],
-  exportName: ExportType
-): SelectableValue<object>[] {
-  const options: SelectableValue<object>[] = [];
-  for (const component of components) {
-    let spec: BlockType | null = null;
-    if (component.name.startsWith("module.git")) {
-      const repo = component.attributes.find(
-        (x) => x.name === "repository"
-      ) as Attribute | null;
-      const path = component.attributes.find(
-        (x) => x.name === "path"
-      ) as Attribute | null;
-      if (repo && path && KnownModules[repo.value]) {
-        spec = KnownModules[repo.value][path.value];
-      }
-    } else {
-      spec = KnownComponents[component.name];
-    }
-    if (!spec) continue;
-    for (const en of Object.keys(spec.exports)) {
-      if (spec.exports[en] === exportName) {
-        if (component.label) {
-          options.push({
-            label: `${component.label} [${component.name}]`,
-            value: {
-              "-reference": `${component.name}.${component.label}.${en}`,
-            },
-          });
-        } else {
-          options.push({
-            label: `${component.name}`,
-            value: {
-              "-reference": `${component.name}.${en}`,
-            },
-          });
-        }
-      }
-    }
-  }
-  return options;
-}
+import { ReferenceSelectProps, toOptions } from "./ReferenceSelectBase";
 
 const ReferenceSelect = ({
   control,
   name,
   exportName,
   width,
-}: {
-  control: Control<Record<string, any>>;
-  name: string;
-  exportName: ExportType;
-  width?: number;
-}) => {
+  defaultValue,
+  rules,
+}: ReferenceSelectProps<{ "-reference": string }>) => {
   const { components } = useComponentContext();
-  const defaultValue = control.defaultValuesRef.current[name];
+  defaultValue = defaultValue ?? get(control.defaultValuesRef.current, name);
   const [value, setValue] = useState<SelectableValue<object>>(() => {
     if (!defaultValue) return null;
-    if ("-reference" in defaultValue)
-      return { label: defaultValue["-reference"], value: defaultValue };
-    else return { label: JSON.stringify(defaultValue), value: defaultValue };
+    return { label: defaultValue["-reference"], value: defaultValue };
   });
-  const [customOptions, setCustomOptions] = useState<
-    Array<SelectableValue<any>>
-  >([]);
   const targetComponents = toOptions(
     components.map((x) => x.block),
-    exportName
+    exportName,
   );
   return (
     <InputControl
       render={({ field: { onChange, ref, ...field } }) => (
         <Select
           {...field}
-          options={[...targetComponents, ...customOptions]}
-          allowCustomValue={true}
+          options={targetComponents}
           onChange={(v) => {
             onChange(v.value);
             setValue(v);
           }}
           value={value}
           width={width}
-          onCreateOption={(newOption) => {
-            const customValue: SelectableValue<object> = {
-              value: JSON.parse(newOption),
-              label: newOption,
-            };
-            setCustomOptions([...customOptions, customValue]);
-            setValue(customValue);
-          }}
         />
       )}
       control={control}
       name={name}
+      rules={rules || {}}
     />
   );
 };

--- a/src/components/ComponentEditor/inputs/ReferenceSelectBase.tsx
+++ b/src/components/ComponentEditor/inputs/ReferenceSelectBase.tsx
@@ -1,0 +1,63 @@
+import { SelectableValue } from "@grafana/data";
+import { Control } from "react-hook-form";
+import { Attribute, Block } from "../../../lib/river";
+
+import {
+  BlockType,
+  ExportType,
+  KnownComponents,
+  KnownModules,
+} from "../../../lib/components";
+
+export function toOptions(
+  components: Block[],
+  exportName: ExportType,
+): SelectableValue<object>[] {
+  const options: SelectableValue<object>[] = [];
+  for (const component of components) {
+    let spec: BlockType | null = null;
+    if (component.name.startsWith("module.git")) {
+      const repo = component.attributes.find(
+        (x) => x.name === "repository",
+      ) as Attribute | null;
+      const path = component.attributes.find(
+        (x) => x.name === "path",
+      ) as Attribute | null;
+      if (repo && path && KnownModules[repo.value]) {
+        spec = KnownModules[repo.value][path.value];
+      }
+    } else {
+      spec = KnownComponents[component.name];
+    }
+    if (!spec) continue;
+    for (const en of Object.keys(spec.exports)) {
+      if (spec.exports[en] === exportName) {
+        if (component.label) {
+          options.push({
+            label: `${component.label} [${component.name}]`,
+            value: {
+              "-reference": `${component.name}.${component.label}.${en}`,
+            },
+          });
+        } else {
+          options.push({
+            label: `${component.name}`,
+            value: {
+              "-reference": `${component.name}.${en}`,
+            },
+          });
+        }
+      }
+    }
+  }
+  return options;
+}
+
+export type ReferenceSelectProps<T> = {
+  control: Control<Record<string, any>>;
+  name: string;
+  exportName: ExportType;
+  width?: number;
+  defaultValue?: T;
+  rules?: object;
+};


### PR DESCRIPTION
option creation does not make sense now that we can toggle between static and reference mode